### PR TITLE
Fix Download Behind Proxy

### DIFF
--- a/lib/nerves_system/providers/http.ex
+++ b/lib/nerves_system/providers/http.ex
@@ -4,7 +4,6 @@ defmodule Nerves.System.Providers.Http do
   @recv_timeout 120_000
 
   def cache_get(_system, _version, config, destination) do
-    Application.ensure_all_started(:httpoison)
     shell_info "Downloading system from cache"
     config[:mirrors]
     |> get
@@ -19,11 +18,11 @@ defmodule Nerves.System.Providers.Http do
     mirror
     |> URI.encode
     |> String.replace("+", "%2B")
-    |> HTTPoison.get([], [follow_redirect: true, recv_timeout: @recv_timeout])
+    |> Mix.Utils.read_path()
     |> result(mirrors)
   end
 
-  defp result({:ok, %{status_code: status, body: body}}, _) when status in 200..299 do
+  defp result({:ok, body}, _) do
     shell_info "System Downloaded"
     {:ok, body}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -31,8 +31,7 @@ defmodule Nerves.System.Mixfile do
   end
 
   defp deps do
-    [{:httpoison, "~> 0.8.3"},
-     {:porcelain, "~> 2.0"}]
+    [{:porcelain, "~> 2.0"}]
   end
 
   defp description do


### PR DESCRIPTION
This fixes the issue with trying to run behind a proxy server.

There is a long standing bug in Hackney (and thus HTTPoison) that prevents redirects from working correctly with a proxy server.  See edgurgel/httpoison#112.  

I tried fixing the bug upstream in hackney, but it is non-trivial.  Luckily, Mix already has a Utility function that accomplishes the same thing.  

See also nerves-project/nerves_toolchain#2